### PR TITLE
Setup Rust Core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["rust-core"]
+resolver = "2"

--- a/rust-core/Cargo.toml
+++ b/rust-core/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "paperplane-core"
+version = "0.1.0"
+edition = "2021"
+description = "Core execution engine for Paperplane"
+
+[lib]
+name = "paperplane_core"
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "paperplane"
+path = "src/main.rs"
+
+[dependencies]
+tauri = { version = "2", features = ["macos-private-api"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["full"] }
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true

--- a/rust-core/build.rs
+++ b/rust-core/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/rust-core/src/commands/mod.rs
+++ b/rust-core/src/commands/mod.rs
@@ -1,3 +1,6 @@
+// IPC command handlers exposed to the frontend via Tauri's invoke bridge.
+// Each function tagged with #[tauri::command] becomes callable from JS/TS.
+
 /// Health-check command — verifies IPC bridge is working.
 #[tauri::command]
 pub fn ping() -> &'static str {

--- a/rust-core/src/commands/mod.rs
+++ b/rust-core/src/commands/mod.rs
@@ -1,0 +1,5 @@
+/// Health-check command — verifies IPC bridge is working.
+#[tauri::command]
+pub fn ping() -> &'static str {
+    "pong"
+}

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod commands;
 pub mod models;
 
+/// Initializes and runs the Tauri application.
+/// Command handlers are registered here before the event loop starts.
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![

--- a/rust-core/src/lib.rs
+++ b/rust-core/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod commands;
+pub mod models;
+
+pub fn run() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            commands::ping,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running Paperplane");
+}

--- a/rust-core/src/main.rs
+++ b/rust-core/src/main.rs
@@ -1,0 +1,6 @@
+// Prevents an extra console window on Windows in release
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    paperplane_core::run();
+}

--- a/rust-core/src/models/mod.rs
+++ b/rust-core/src/models/mod.rs
@@ -1,3 +1,6 @@
+// Core data models shared across the engine.
+// Serialized with serde so they can cross the Tauri IPC boundary as JSON.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/rust-core/src/models/mod.rs
+++ b/rust-core/src/models/mod.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// An outgoing HTTP request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub method: String,
+    pub url: String,
+    pub headers: HashMap<String, String>,
+    pub body: Option<String>,
+}
+
+/// The result of executing an HTTP request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Response {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: String,
+    pub duration_ms: u64,
+}

--- a/rust-core/tauri.conf.json
+++ b/rust-core/tauri.conf.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Paperplane",
+  "version": "0.1.0",
+  "identifier": "dev.paperplane.app",
+  "build": {
+    "frontendDist": "../apps/desktop/dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "Paperplane",
+        "width": 1200,
+        "height": 800,
+        "resizable": true,
+        "fullscreen": false
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": []
+  }
+}


### PR DESCRIPTION
## Summary
- Add root `Cargo.toml` workspace manifest pointing to `rust-core`
- Configure `paperplane-core` crate with Tauri 2, reqwest, serde, tokio
- Scaffold module structure: `commands/`, `models/`, `main.rs`, `lib.rs`
- Add `tauri.conf.json` with base Tauri app configuration

## Test plan
- [ ] `cargo build --workspace` completes with no errors/warnings
- [ ] CI build passes
- [ ] `commands::ping` IPC command is reachable from frontend

Closes #40
